### PR TITLE
fix: load paths to git repositories at start-time; versions endpoint fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           tool: nextest
       - name: Run tests (nextest)
-        run: just nextest
+        run: just test
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "stelae"
-version = "0.3.0-alpha.5"
+version = "0.3.0-alpha.6"
 dependencies = [
  "actix-http",
  "actix-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stelae"
 description = "A collection of tools in Rust and Python for preserving, authenticating, and accessing laws in perpetuity."
-version = "0.3.0-alpha.5"
+version = "0.3.0-alpha.6"
 edition = "2021"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/justfile
+++ b/justfile
@@ -13,8 +13,6 @@ format:
 
 # Run all tests
 test:
-  cargo test
-nextest:
   cargo nextest run --all --no-fail-fast && cargo test --doc
 
 # Run clippy maximum strictness. Passes through any flags to clippy.
@@ -25,7 +23,7 @@ clippy *FLAGS:
     -D warnings \
 
 # Continuous integration - test, lint, benchmark
-ci: lint nextest bench
+ci: lint test bench
 
 # Run all benchmarks
 bench:

--- a/src/server/api/versions/response/mod.rs
+++ b/src/server/api/versions/response/mod.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Reverse, collections::BTreeMap};
 
+use chrono::NaiveDate;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -166,13 +167,18 @@ impl Version {
 
     /// Insert a new version if it is not present in the list of versions.
     /// If the date is not in the list of versions, add it
+    /// Do nothing if the date is already in the list of versions.
     /// This for compatibility purposes with the previous implementation of historical versions
     pub fn insert_if_not_present(versions: &mut Vec<Self>, date: Option<String>) {
-        if let Some(version_date) = date {
-            if versions.iter().all(|ver| ver.date != version_date) {
-                let version = Self::new(version_date.clone(), version_date, 0);
-                Self::insert_version_sorted(versions, version);
-            }
+        let Some(version_date) = date else {
+            return;
+        };
+        if NaiveDate::parse_from_str(&version_date, "%Y-%m-%d").is_err() {
+            return;
+        }
+        if versions.iter().all(|ver| ver.date != version_date) {
+            let version = Self::new(version_date.clone(), version_date, 0);
+            Self::insert_version_sorted(versions, version);
         }
     }
 

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,5 +1,6 @@
 //! The git module contains structs for interacting with git repositories
 //! in the Stelae Archive.
+use crate::utils::paths::clean_path;
 use anyhow::Context;
 use git2::Repository;
 use std::{
@@ -68,6 +69,24 @@ impl Repo {
             path: PathBuf::from(repo_path.clone()),
             repo: Repository::open(repo_path)?,
         })
+    }
+
+    /// Do the work of looking for the requested Git object.
+    ///
+    ///
+    /// # Errors
+    /// Will error if the Repo couldn't be found, or if there was a problem with the Git object.
+    pub fn find_blob(
+        archive_path: &Path,
+        namespace: &str,
+        name: &str,
+        remainder: &str,
+        commitish: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        let repo = Self::new(archive_path, namespace, name)?;
+        let blob_path = clean_path(remainder);
+        let blob = repo.get_bytes_at_path(commitish, &blob_path)?;
+        Ok(blob)
     }
 
     /// Returns bytes of blob found in the commit `commitish` at path `path`


### PR DESCRIPTION
Fixes to stelae we found on our testing environment.

Two notable changes:
- Fix to `_compare` endpoint to not include an additional `current` date if the request url contains `/current`. 
- `stelae serve` command is changed to load paths to git repositories instead of keeping git repository handles open. This makes it so that the command won't fail in cases where data repos aren't on disk. Moreover, if/when data repositories become available on disk, `stelae serve` will work.