### PR TITLE
fix: send "404 Not Found" body on error response

### DIFF
--- a/src/server/api/serve/mod.rs
+++ b/src/server/api/serve/mod.rs
@@ -2,7 +2,10 @@
 #![allow(clippy::infinite_loop)]
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 
-use crate::utils::{git::Repo, http::get_contenttype, paths::clean_path};
+use crate::{
+    server::errors::HTTPError,
+    utils::{git::Repo, http::get_contenttype, paths::clean_path},
+};
 
 use super::state::{RepoData as RepoState, Shared as SharedState};
 /// Most-recent git commit
@@ -29,7 +32,7 @@ pub async fn serve(
         Ok(content) => HttpResponse::Ok().insert_header(contenttype).body(content),
         Err(error) => {
             tracing::debug!("{path}: {error}",);
-            HttpResponse::BadRequest().into()
+            HttpResponse::NotFound().body(HTTPError::NotFound.to_string())
         }
     }
 }

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -10,6 +10,17 @@ use actix_web::{error, http::StatusCode, HttpResponse};
 use derive_more::{Display, Error};
 use std::io;
 
+/// Collection of possible HTTP errors
+#[derive(Debug, Display, Error)]
+pub enum HTTPError {
+    #[display(fmt = "404 Not Found")]
+    /// 404
+    NotFound,
+    #[display(fmt = "Unexpected server error")]
+    /// 500
+    InternalServerError,
+}
+
 /// Collection of possible CLI errors
 #[derive(Debug, Display, Error)]
 pub enum CliError {

--- a/src/server/git.rs
+++ b/src/server/git.rs
@@ -14,7 +14,7 @@ use git2::{self, ErrorCode};
 use std::path::PathBuf;
 use tracing_actix_web::TracingLogger;
 
-use super::errors::{CliError, StelaeError};
+use super::errors::{CliError, HTTPError, StelaeError};
 use crate::utils::git::{Repo, GIT_REQUEST_NOT_FOUND};
 use crate::utils::http::get_contenttype;
 use crate::{server::tracing::StelaeRootSpanBuilder, utils::paths::clean_path};
@@ -77,9 +77,9 @@ fn blob_error_response(error: &anyhow::Error, namespace: &str, name: &str) -> Ht
     match error {
         // TODO: Obviously it's better to use custom `Error` types
         _ if error.to_string() == GIT_REQUEST_NOT_FOUND => {
-            HttpResponse::NotFound().body(GIT_REQUEST_NOT_FOUND)
+            HttpResponse::NotFound().body(HTTPError::NotFound.to_string())
         }
-        _ => HttpResponse::InternalServerError().body("Unexpected server error"),
+        _ => HttpResponse::InternalServerError().body(HTTPError::InternalServerError.to_string()),
     }
 }
 


### PR DESCRIPTION
Send an error response that more accurately conveys the type of error on response.