### PR TITLE
fix: resolve to `_api/versions` requests without trailing `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+## [0.3.1]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix resolve to `_api/versions` requests without trailing `/` ([52])
+
+### Removed
+
+[52]: https://github.com/openlawlibrary/stelae/pull/52
+
 ## [0.3.0]
 
 ### Added
@@ -96,7 +110,8 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
-[Unreleased]: https://github.com/openlawlibrary/stelae/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/openlawlibrary/stelae/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/openlawlibrary/stelae/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/openlawlibrary/stelae/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/openlawlibrary/stelae/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/openlawlibrary/stelae/compare/v0.1.1...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "stelae"
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 dependencies = [
  "actix-http",
  "actix-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "stelae"
-version = "0.3.1-alpha.1"
+version = "0.3.1"
 dependencies = [
  "actix-http",
  "actix-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stelae"
 description = "A collection of tools in Rust and Python for preserving, authenticating, and accessing laws in perpetuity."
-version = "0.3.1-alpha.1"
+version = "0.3.1"
 edition = "2021"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stelae"
 description = "A collection of tools in Rust and Python for preserving, authenticating, and accessing laws in perpetuity."
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 edition = "2021"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/src/server/api/routes.rs
+++ b/src/server/api/routes.rs
@@ -45,6 +45,10 @@ pub fn register_app<
             web::scope("/_api").service(
                 web::scope("/versions")
                     .service(
+                        web::resource("/_publication/{publication}/_compare/{date}/{compare_date}")
+                            .to(versions),
+                    )
+                    .service(
                         web::resource(
                             "/_publication/{publication}/_compare/{date}/{compare_date}/{path:.*}",
                         )
@@ -53,9 +57,11 @@ pub fn register_app<
                     .service(web::resource("/_publication/{publication}/_date/{date}").to(versions))
                     .service(web::resource("/_publication/{publication}").to(versions))
                     .service(web::resource("/_publication/{publication}/{path:.*}").to(versions))
+                    .service(web::resource("/_compare/{date}/{compare_date}").to(versions))
                     .service(
                         web::resource("/_compare/{date}/{compare_date}/{path:.*}").to(versions),
                     )
+                    .service(web::resource("/_date/{date}").to(versions))
                     .service(web::resource("/_date/{date}/{path:.*}").to(versions))
                     .service(web::resource("/{path:.*}").to(versions))
                     .service(web::resource("").to(versions)),


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #51 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/