### PR TITLE
fix: allow `HEAD` method for dynamic routes

### DIFF
--- a/src/server/api/routes.rs
+++ b/src/server/api/routes.rs
@@ -249,6 +249,7 @@ fn register_root_routes(cfg: &mut web::ServiceConfig, stele: &Stele) -> anyhow::
                 root_scope = root_scope.service(
                     web::resource(actix_route.as_str())
                         .route(web::get().to(serve))
+                        .route(web::head().to(serve))
                         .app_data(web::Data::new(repo_state.clone())),
                 );
             }
@@ -257,6 +258,7 @@ fn register_root_routes(cfg: &mut web::ServiceConfig, stele: &Stele) -> anyhow::
                     web::scope("").service(
                         web::resource("/{tail:.*}")
                             .route(web::get().to(serve))
+                            .route(web::head().to(serve))
                             .app_data(web::Data::new(repo_state.clone())),
                     ),
                 );
@@ -298,6 +300,7 @@ fn register_dependent_routes(
                 actix_scope = actix_scope.service(
                     web::resource(actix_route.as_str())
                         .route(web::get().to(serve))
+                        .route(web::head().to(serve))
                         .app_data(web::Data::new(repo_state.clone())),
                 );
             }

--- a/src/server/git.rs
+++ b/src/server/git.rs
@@ -9,7 +9,7 @@
     clippy::infinite_loop
 )]
 
-use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, route, web, App, HttpResponse, HttpServer, Responder};
 use git2::{self, ErrorCode};
 use std::path::PathBuf;
 use tracing_actix_web::TracingLogger;
@@ -43,7 +43,11 @@ async fn misc(path: web::Path<String>) -> actix_web::Result<&'static str, Stelae
 /// Return the content in the stelae archive in the `{namespace}/{name}`
 /// repo at the `commitish` commit at the `remainder` path.
 /// Return 404 if any are not found or there are any errors.
-#[get("/{namespace}/{name}/{commitish}{remainder:/+([^{}]*?)?/*}")]
+#[route(
+    "/{namespace}/{name}/{commitish}{remainder:/+([^{}]*?)?/*}",
+    method = "GET",
+    method = "HEAD"
+)]
 #[tracing::instrument(name = "Retrieving a Git blob", skip(path, data))]
 async fn get_blob(
     path: web::Path<(String, String, String, String)>,


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

stelae is now able to resolve requests with HEAD method.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/