### PR TITLE
feat: Insert commit hashes

### DIFF
--- a/migrations/sqlite/20241203180217_add_commits.down.sql
+++ b/migrations/sqlite/20241203180217_add_commits.down.sql
@@ -1,0 +1,8 @@
+-- Add down migration script here
+PRAGMA foreign_keys = OFF;
+
+DROP INDEX IF EXISTS auth_commits_hash_unq_idx;
+DROP TABLE IF EXISTS data_repo_commits;
+DROP TABLE IF EXISTS auth_repo_commits;
+
+PRAGMA optimize;

--- a/migrations/sqlite/20241203180217_add_commits.up.sql
+++ b/migrations/sqlite/20241203180217_add_commits.up.sql
@@ -1,0 +1,33 @@
+-- Add up migration script here
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE auth_commits (
+    commit_hash TEXT,
+    timestamp INTEGER,
+    publication_version_id TEXT,
+    CONSTRAINT fk_auth_commits_publication_version
+        FOREIGN KEY (publication_version_id)
+        REFERENCES publication_version(id)
+        ON DELETE CASCADE,
+    PRIMARY KEY (commit_hash, publication_version_id)
+);
+CREATE TABLE data_commits (
+    commit_hash TEXT,
+    date TEXT,
+    data_repo_type TEXT,
+    auth_commit_hash TEXT,
+    publication_id TEXT,
+    CONSTRAINT fk_data_commits_auth_commit
+        FOREIGN KEY (auth_commit_hash)
+        REFERENCES auth_commits(commit_hash)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_data_commits_publication
+        FOREIGN KEY (publication_id)
+        REFERENCES publication(id)
+        ON DELETE CASCADE,
+    PRIMARY KEY (commit_hash, auth_commit_hash)
+);
+
+CREATE UNIQUE INDEX auth_commits_hash_unq_idx ON auth_commits(commit_hash);
+
+PRAGMA optimize;

--- a/src/db/models/auth_commits/manager.rs
+++ b/src/db/models/auth_commits/manager.rs
@@ -1,0 +1,42 @@
+//! Manager for the auth commit model.
+
+use async_trait::async_trait;
+use sqlx::QueryBuilder;
+
+use crate::db::{models::BATCH_SIZE, DatabaseTransaction};
+
+use super::AuthCommits;
+
+#[async_trait]
+impl super::TxManager for DatabaseTransaction {
+    /// Find all authentication commits.
+    ///
+    /// # Errors
+    /// Errors if the commits cannot be found.
+    async fn find_all(&mut self) -> anyhow::Result<Vec<AuthCommits>> {
+        let statement = "SELECT * FROM auth_commits";
+        let rows = sqlx::query_as::<_, AuthCommits>(statement)
+            .fetch_all(&mut *self.tx)
+            .await?;
+        Ok(rows)
+    }
+    /// Upsert a bulk of authentication commits into the database.
+    ///
+    /// # Errors
+    /// Errors if the commits cannot be inserted.
+    async fn insert_bulk(&mut self, auth_commits: Vec<AuthCommits>) -> anyhow::Result<()> {
+        let mut query_builder = QueryBuilder::new("INSERT OR IGNORE INTO auth_commits ( commit_hash, timestamp, publication_version_id ) ");
+        for chunk in auth_commits.chunks(BATCH_SIZE) {
+            query_builder.push_values(chunk, |mut bindings, ac| {
+                bindings
+                    .push_bind(&ac.commit_hash)
+                    .push_bind(&ac.timestamp)
+                    .push_bind(&ac.publication_version_id);
+            });
+            let query = query_builder.build();
+            query.execute(&mut *self.tx).await?;
+            query_builder.reset();
+        }
+        Ok(())
+    }
+}

--- a/src/db/models/auth_commits/mod.rs
+++ b/src/db/models/auth_commits/mod.rs
@@ -1,0 +1,54 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use sqlx::{any::AnyRow, FromRow, Row};
+
+pub mod manager;
+
+/// Trait for managing transactional authentication commits.
+#[async_trait]
+pub trait TxManager {
+    /// Find all authentication commits.
+    async fn find_all(&mut self) -> anyhow::Result<Vec<AuthCommits>>;
+    /// Insert a bulk of auth commits.
+    async fn insert_bulk(&mut self, auth_commits: Vec<AuthCommits>) -> anyhow::Result<()>;
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+/// Table used for the commits within the authentication repository.
+pub struct AuthCommits {
+    /// Unique commit hash of the authentication repository.
+    pub commit_hash: String,
+    /// Timestamp of the time the commit was created.
+    pub timestamp: String,
+    /// Foreign key reference to the publication version.
+    pub publication_version_id: Option<String>,
+}
+
+/// NOTE: current sqlx version does not support `Option` types in `FromRow` trait.
+/// For now, we manually implement the `FromRow` for the struct.
+/// From version 0.8.0, sqlx has resolved the issue.
+impl FromRow<'_, AnyRow> for AuthCommits {
+    fn from_row(row: &AnyRow) -> anyhow::Result<Self, sqlx::Error> {
+        Ok(Self {
+            commit_hash: row.try_get("commit_hash")?,
+            timestamp: row.try_get("timestamp")?,
+            publication_version_id: row.try_get("publication_version_id").ok(),
+        })
+    }
+}
+
+impl AuthCommits {
+    /// Create a new authentication commit.
+    #[must_use]
+    pub const fn new(
+        commit_hash: String,
+        timestamp: String,
+        publication_version_id: Option<String>,
+    ) -> Self {
+        Self {
+            commit_hash,
+            timestamp,
+            publication_version_id,
+        }
+    }
+}

--- a/src/db/models/data_commits/manager.rs
+++ b/src/db/models/data_commits/manager.rs
@@ -1,0 +1,32 @@
+//! Manager for the data repo commit model.
+use async_trait::async_trait;
+use sqlx::QueryBuilder;
+
+use crate::db::{models::BATCH_SIZE, DatabaseTransaction};
+
+use super::DataCommits;
+
+#[async_trait]
+impl super::TxManager for DatabaseTransaction {
+    /// Upsert a bulk of data repository commits into the database.
+    ///
+    /// # Errors
+    /// Errors if the commits cannot be inserted.
+    async fn insert_bulk(&mut self, data_commits: Vec<DataCommits>) -> anyhow::Result<()> {
+        let mut query_builder = QueryBuilder::new("INSERT OR IGNORE INTO data_commits ( commit_hash, date, data_repo_type, auth_commit_hash, publication_id ) ");
+        for chunk in data_commits.chunks(BATCH_SIZE) {
+            query_builder.push_values(chunk, |mut bindings, dc| {
+                bindings
+                    .push_bind(&dc.commit_hash)
+                    .push_bind(&dc.date)
+                    .push_bind(&dc.data_repo_type)
+                    .push_bind(&dc.auth_commit_hash)
+                    .push_bind(&dc.publication_id);
+            });
+            let query = query_builder.build();
+            query.execute(&mut *self.tx).await?;
+            query_builder.reset();
+        }
+        Ok(())
+    }
+}

--- a/src/db/models/data_commits/mod.rs
+++ b/src/db/models/data_commits/mod.rs
@@ -1,0 +1,46 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub mod manager;
+
+/// Trait for managing transactional data repo commits.
+#[async_trait]
+pub trait TxManager {
+    /// Insert a bulk of data repo commits.
+    async fn insert_bulk(&mut self, data_commits: Vec<DataCommits>) -> anyhow::Result<()>;
+}
+
+#[derive(sqlx::FromRow, Debug, Deserialize, Serialize)]
+/// Model for the commits within the data repository.
+pub struct DataCommits {
+    /// Unique commit hash of the authentication repository.
+    pub commit_hash: String,
+    /// Either codified date or date on which the commit was built on (build-date).
+    pub date: String,
+    /// Type of the data repository. E.g. `html`.
+    pub data_repo_type: String,
+    /// Foreign key reference to the authentication commit hash.
+    pub auth_commit_hash: String,
+    /// Foreign key reference to the publication.
+    pub publication_id: String,
+}
+
+impl DataCommits {
+    /// Create a new data commit.
+    #[must_use]
+    pub const fn new(
+        commit_hash: String,
+        date: String,
+        data_repo_type: String,
+        auth_commit_hash: String,
+        publication_id: String,
+    ) -> Self {
+        Self {
+            commit_hash,
+            date,
+            data_repo_type,
+            auth_commit_hash,
+            publication_id,
+        }
+    }
+}

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -3,8 +3,12 @@
 /// Size of the batch for bulk inserts.
 const BATCH_SIZE: usize = 1000;
 
+/// module for interacting with `auth_commits` table.
+pub mod auth_commits;
 /// module for interacting with the `changed_library_document` table.
 pub mod changed_library_document;
+/// module for interacting with the `data_repos` table.
+pub mod data_commits;
 /// module for interacting with the `document` table.
 pub mod document;
 /// module for interacting with the `document_change` table.

--- a/src/db/models/publication/manager.rs
+++ b/src/db/models/publication/manager.rs
@@ -106,7 +106,7 @@ impl super::TxManager for DatabaseTransaction {
         Ok(row)
     }
 
-    /// Find a publication by `name` and `date` and `stele_id`.
+    /// Find a publication by `name` and `stele_id`.
     ///
     /// # Errors
     /// Errors if can't establish a connection to the database.
@@ -118,7 +118,7 @@ impl super::TxManager for DatabaseTransaction {
         let statement = "
             SELECT *
             FROM publication
-            WHERE name = $1 AND stele = $2
+            WHERE name = $1 AND stele = $2 AND revoked = 0
         ";
         let row = sqlx::query_as::<_, Publication>(statement)
             .bind(name)

--- a/src/db/models/publication_version/manager.rs
+++ b/src/db/models/publication_version/manager.rs
@@ -99,6 +99,26 @@ impl super::TxManager for DatabaseTransaction {
         Ok(rows)
     }
 
+    /// Find a publication version by a `publication_id` and `version`.
+    async fn find_by_publication_id_and_version(
+        &mut self,
+        publication_id: &str,
+        version: &str,
+    ) -> anyhow::Result<Option<PublicationVersion>> {
+        let statement = "
+            SELECT *
+            FROM publication_version
+            WHERE publication_id = $1 AND version = $2
+        ";
+        let row = sqlx::query_as::<_, PublicationVersion>(statement)
+            .bind(publication_id)
+            .bind(version)
+            .fetch_one(&mut *self.tx)
+            .await
+            .ok();
+        Ok(row)
+    }
+
     /// Recursively find all publication versions starting from a given publication ID.
 
     /// This is necessary because publication versions can be the same across publications.

--- a/src/db/models/publication_version/mod.rs
+++ b/src/db/models/publication_version/mod.rs
@@ -34,9 +34,15 @@ pub trait TxManager {
         &mut self,
         publication_id: String,
     ) -> anyhow::Result<Vec<PublicationVersion>>;
+    /// Find a publication version by a `publication_id` and `version`.
+    async fn find_by_publication_id_and_version(
+        &mut self,
+        publication_id: &str,
+        version: &str,
+    ) -> anyhow::Result<Option<PublicationVersion>>;
 }
 
-#[derive(Deserialize, Serialize, Hash, Eq, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Hash, Eq, PartialEq, Clone)]
 /// Model for a Stele.
 pub struct PublicationVersion {
     /// A hashed identifier for the publication version.

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -108,26 +108,24 @@ async fn process_stele(
     stele: &mut Stele,
     archive_path: &Path,
 ) -> anyhow::Result<()> {
-    let Ok(found_repositories) = stele.get_repositories() else {
+    let Some(repositories) = stele.get_repositories()? else {
         tracing::warn!("No repositories found for stele: {name}");
         return Ok(());
     };
-    if let Some(repositories) = found_repositories {
-        let Some(rdf_repo) = repositories.get_rdf_repository() else {
-            tracing::warn!("No RDF repository found for stele: {name}");
-            return Ok(());
-        };
-        let rdf_repo_path = archive_path.to_path_buf().join(&rdf_repo.name);
-        if !rdf_repo_path.exists() {
-            return Err(anyhow::anyhow!(
-                "RDF repository should exist on disk but not found: {}",
-                rdf_repo_path.display()
-            ));
-        }
-        let (rdf_org, rdf_name) = get_name_parts(&rdf_repo.name)?;
-        let rdf = Repo::new(archive_path, &rdf_org, &rdf_name)?;
-        insert_changes_from_rdf_repository(conn, rdf, name).await?;
+    let Some(rdf_repo) = repositories.get_rdf_repository() else {
+        tracing::warn!("No RDF repository found for stele: {name}");
+        return Ok(());
+    };
+    let rdf_repo_path = archive_path.to_path_buf().join(&rdf_repo.name);
+    if !rdf_repo_path.exists() {
+        return Err(anyhow::anyhow!(
+            "RDF repository should exist on disk but not found: {}",
+            rdf_repo_path.display()
+        ));
     }
+    let (rdf_org, rdf_name) = get_name_parts(&rdf_repo.name)?;
+    let rdf = Repo::new(archive_path, &rdf_org, &rdf_name)?;
+    insert_changes_from_rdf_repository(conn, rdf, name).await?;
     Ok(())
 }
 

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -146,7 +146,7 @@ async fn process_stele(
         if data_repo.custom.repository_type.as_deref() != Some("html") {
             continue;
         }
-        insert_commit_hashes_from_auth_repository(tx, &stele, &data_repo).await?;
+        insert_commit_hashes_from_auth_repository(tx, stele, data_repo).await?;
     }
     Ok(())
 }

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -6,7 +6,9 @@
     clippy::string_add
 )]
 use super::rdf::graph::Bag;
+use crate::db::models::auth_commits::{self, AuthCommits};
 use crate::db::models::changed_library_document::{self, ChangedLibraryDocument};
+use crate::db::models::data_commits::{self, DataCommits};
 use crate::db::models::document_change::{self, DocumentChange};
 use crate::db::models::document_element::DocumentElement;
 use crate::db::models::library::{self, Library};

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -157,8 +157,8 @@ async fn insert_changes_from_rdf_repository(
     rdf_repo: Repo,
     stele_id: &str,
 ) -> anyhow::Result<()> {
-    tracing::info!("Inserting changes from RDF repository: {}", stele_id);
-    tracing::info!("RDF repository path: {}", rdf_repo.path.display());
+    tracing::debug!("Inserting changes from RDF repository: {}", stele_id);
+    tracing::debug!("RDF repository path: {}", rdf_repo.path.display());
     load_delta_for_stele(tx, &rdf_repo, stele_id).await?;
     Ok(())
 }
@@ -171,10 +171,10 @@ async fn load_delta_for_stele(
 ) -> anyhow::Result<()> {
     stele::TxManager::create(tx, stele).await?;
     if let Some(publication) = publication::TxManager::find_last_inserted(tx, stele).await? {
-        tracing::info!("Inserting changes from last inserted publication");
+        tracing::info!("[{stele}] | Inserting RDF changes from last inserted publication");
         load_delta_from_publications(tx, rdf_repo, stele, Some(publication)).await?;
     } else {
-        tracing::info!("Inserting changes from beginning for stele: {}", stele);
+        tracing::info!("[{stele}] | Inserting RDF changes from beginning...");
         load_delta_from_publications(tx, rdf_repo, stele, None).await?;
     }
     Ok(())

--- a/src/server/api/routes.rs
+++ b/src/server/api/routes.rs
@@ -240,7 +240,7 @@ fn register_routes<T: Global>(cfg: &mut web::ServiceConfig, state: &T) -> anyhow
 fn register_root_routes(cfg: &mut web::ServiceConfig, stele: &Stele) -> anyhow::Result<()> {
     let mut root_scope: Scope = web::scope("");
     if let Some(repositories) = stele.repositories.as_ref() {
-        let sorted_repositories = repositories.get_sorted_repositories();
+        let sorted_repositories = repositories.get_sorted();
         for repository in sorted_repositories {
             let custom = &repository.custom;
             let repo_state = state::init_repo(repository, stele)?;
@@ -281,7 +281,7 @@ fn register_dependent_routes(
     stele: &Stele,
     repositories: &Repositories,
 ) -> anyhow::Result<()> {
-    let sorted_repositories = repositories.get_sorted_repositories();
+    let sorted_repositories = repositories.get_sorted();
     for scope in repositories.scopes.iter().flat_map(|scopes| scopes.iter()) {
         let scope_str = format!("/{{prefix:{}}}", &scope.as_str());
         let mut actix_scope = web::scope(scope_str.as_str());

--- a/src/stelae/stele.rs
+++ b/src/stelae/stele.rs
@@ -107,6 +107,8 @@ impl Stele {
     ///
     /// # Returns
     /// Returns the targets metadata file if found, or None if not found.
+    /// # Errors
+    /// Will error if unable to find or parse targets metadata file at `targets/{org}/{filename}`
     pub fn get_targets_metadata_at_commit_and_filename(
         &self,
         committish: &str,

--- a/src/stelae/types/mod.rs
+++ b/src/stelae/types/mod.rs
@@ -1,4 +1,5 @@
-//! The Types module contains data models for Stelae.
+//! The `types` module contains data models for stelae.
 
 pub mod dependencies;
 pub mod repositories;
+pub mod targets_metadata;

--- a/src/stelae/types/repositories.rs
+++ b/src/stelae/types/repositories.rs
@@ -70,14 +70,20 @@ impl Repository {
     /// The org is the first part of the name, before the `/`.
     #[must_use]
     pub fn get_org(&self) -> String {
-        self.name.split('/').next().unwrap_or_default().to_string()
+        self.name.split('/').next().unwrap_or_default().to_owned()
     }
 
     /// Get the name of the repository.
     /// The name is the second part of the name, after the `/`.
     #[must_use]
     pub fn get_name(&self) -> String {
-        self.name.split('/').nth(1).unwrap_or_default().to_string()
+        self.name.split('/').nth(1).unwrap_or_default().to_owned()
+    }
+
+    /// Get the type of the repository.
+    #[must_use]
+    pub fn get_type(&self) -> Option<String> {
+        self.custom.repository_type.clone()
     }
 }
 
@@ -134,6 +140,7 @@ impl Repositories {
     }
 
     /// Filter and return a `Repository` by it's custom type.
+    #[must_use]
     pub fn get_one_by_custom_type(&self, repository_type: &str) -> Option<&Repository> {
         self.repositories.values().find(|repository| {
             repository.custom.repository_type.as_deref() == Some(repository_type)
@@ -141,6 +148,7 @@ impl Repositories {
     }
 
     /// Filter and return a `Repository` by it's serve type.
+    #[must_use]
     pub fn get_all_by_custom_type(&self, repository_type: &str) -> Vec<&Repository> {
         self.repositories
             .values()
@@ -182,6 +190,7 @@ impl Repositories {
     /// let repos = repositories.get_all_by_serve_type(serve_type);
     /// assert_eq!(repos.len(), 2);
     /// ```
+    #[must_use]
     pub fn get_all_by_serve_type(&self, serve_type: &str) -> Vec<&Repository> {
         self.repositories
             .values()

--- a/src/stelae/types/repositories.rs
+++ b/src/stelae/types/repositories.rs
@@ -100,7 +100,7 @@ impl Repositories {
     /// This is needed for serving current documents because Actix routes are matched in the order they are added.
     #[must_use]
     #[allow(clippy::iter_over_hash_type)]
-    pub fn get_sorted_repositories(&self) -> Vec<&Repository> {
+    pub fn get_sorted(&self) -> Vec<&Repository> {
         let mut result = Vec::new();
         for repository in self.repositories.values() {
             result.push(repository);

--- a/src/stelae/types/targets_metadata.rs
+++ b/src/stelae/types/targets_metadata.rs
@@ -1,0 +1,39 @@
+//! Targets metadata types.
+//! Represents the metadata in the `targets/<org>/<data-repo>` file.
+use serde::Deserialize;
+use serde_derive::Serialize;
+
+/// An entry in the `targets/<org>/<data-repo>` file.
+///
+/// Example:
+/// ```rust
+/// use stelae::stelae::types::targets_metadata::TargetsMetadata;
+/// use serde_json::json;
+///
+/// let data = r#"
+/// {
+///    "branch": "publication/2024-09-16",
+///    "build-date": "2024-09-16",
+///    "commit": "1b7334f58f41a53d6e4d9fc11fba6793cb22eb36",
+///    "codified-date": "2024-10-03"
+/// }
+/// "#;
+/// let targets_metadata: TargetsMetadata = serde_json::from_str(data).unwrap();
+/// assert_eq!(targets_metadata.branch, "publication/2024-09-16");
+/// assert_eq!(targets_metadata.build_date.unwrap(), "2024-09-16");
+/// assert_eq!(targets_metadata.commit, "1b7334f58f41a53d6e4d9fc11fba6793cb22eb36");
+/// assert_eq!(targets_metadata.codified_date.unwrap(), "2024-10-03");
+/// ```
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TargetsMetadata {
+    /// A git branch name.
+    pub branch: String,
+    /// The date the build was created.
+    #[serde(rename = "build-date")]
+    pub build_date: Option<String>,
+    /// The commit hash.
+    pub commit: String,
+    /// The date the code was codified.
+    #[serde(rename = "codified-date")]
+    pub codified_date: Option<String>,
+}

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -2,7 +2,7 @@
 //! in the Stelae Archive.
 use crate::utils::paths::clean_path;
 use anyhow::Context;
-use git2::Repository;
+use git2::{Repository, Sort};
 use std::{
     fmt,
     path::{Path, PathBuf},
@@ -123,5 +123,20 @@ impl Repo {
         let obj = self.repo.revparse_single(query)?;
         let blob = obj.as_blob().context("Couldn't cast Git object to blob")?;
         Ok(blob.content().to_owned())
+    }
+
+    /// Instantiates a git revwalk from the beginning of the repository.
+    /// Return an iterator over the commits.
+    ///
+    /// # Errors
+    /// Will error if the revwalk could not be instantiated
+    pub fn iter_commits(&self) -> anyhow::Result<impl Iterator<Item = String>> {
+        let mut revwalk = self.repo.revwalk()?;
+        revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::REVERSE)?;
+        revwalk.push_head().unwrap();
+        Ok(revwalk
+            .map(|id| id.unwrap().to_string())
+            .collect::<Vec<String>>()
+            .into_iter())
     }
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -2,7 +2,7 @@
 //! in the Stelae Archive.
 use crate::utils::paths::clean_path;
 use anyhow::Context;
-use git2::{Repository, Sort};
+use git2::{Commit, Repository, Sort};
 use std::{
     fmt,
     path::{Path, PathBuf},
@@ -130,13 +130,17 @@ impl Repo {
     ///
     /// # Errors
     /// Will error if the revwalk could not be instantiated
-    pub fn iter_commits(&self) -> anyhow::Result<impl Iterator<Item = String>> {
+    pub fn iter_commits(&self) -> anyhow::Result<impl Iterator<Item = Commit>> {
         let mut revwalk = self.repo.revwalk()?;
         revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::REVERSE)?;
-        revwalk.push_head().unwrap();
+        revwalk.push_head()?;
         Ok(revwalk
-            .map(|id| id.unwrap().to_string())
-            .collect::<Vec<String>>()
+            .filter_map(|found_oid| {
+                found_oid
+                    .ok()
+                    .and_then(|oid| self.repo.find_commit(oid).ok())
+            })
+            .collect::<Vec<Commit>>()
             .into_iter())
     }
 }


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #62

- `stelae update` command now adds authentication and data repository commit hashes in the database.
- Add `auth_commits` and `data_commits` sql tables.
- Insert works from the beginning or partially. Add logic to skip inserting commit hashes which have already been inserted.
- Everything that's being inserted is in the same database transaction to keep the database consistent.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/