### PR TITLE
feat: Add `X-File-Path` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Added
 
-### Changed
-
-### Fixed
-
-### Removed
-
-## [0.5.0-alpha.1]
-
-### Added
-
+- Add `X-File-Path` header to `_stelae` and git microserver HTTP responses ([70])
 - Added tests fot `stelae git` ([64])
 
 ### Changed
@@ -32,6 +23,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+[70]: https://github.com/openlawlibrary/stelae/pull/70
 [64]: https://github.com/openlawlibrary/stelae/pull/64
 
 ## [0.4.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Fixed
 
-- Add missing route to versions endpoint ([#68])
+- Add missing route to versions endpoint ([68])
 
 ### Removed
 
@@ -42,18 +42,19 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Added
 
-- Insert commit hashes in the database ([#63])
+- Insert commit hashes in the database ([63])
 
 ### Changed
 
-- Allow HEAD requests for dynamic routes ([#58])
-- Rename `.stelae` to `.taf` dir ([#61])
-- Bump rust-version to `1.83` ([#61])
+- Allow HEAD requests for dynamic routes ([58])
+- Rename `.stelae` to `.taf` dir ([61])
+- Bump rust-version to `1.83` ([61])
 
 ### Fixed
 
 ### Removed
 
+[68]: https://github.com/openlawlibrary/stelae/pull/68
 [63]: https://github.com/openlawlibrary/stelae/pull/63
 [61]: https://github.com/openlawlibrary/stelae/pull/61
 [58]: https://github.com/openlawlibrary/stelae/pull/58
@@ -167,7 +168,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 ### Removed
 
 [Unreleased]: https://github.com/openlawlibrary/stelae/compare/v0.4.1...HEAD
-[0.4.0]: https://github.com/openlawlibrary/stelae/compare/v0.4.0...v0.4.1
+[0.4.1]: https://github.com/openlawlibrary/stelae/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/openlawlibrary/stelae/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/openlawlibrary/stelae/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/openlawlibrary/stelae/compare/v0.3.0...v0.3.1

--- a/src/server/api/stelae/mod.rs
+++ b/src/server/api/stelae/mod.rs
@@ -2,13 +2,13 @@
 
 use std::path::PathBuf;
 
-use actix_web::{web, HttpRequest, HttpResponse, Responder};
-use request::StelaeQueryData;
-
+use crate::server::headers;
 use crate::utils::git::{Repo, GIT_REQUEST_NOT_FOUND};
 use crate::utils::http::get_contenttype;
 use crate::utils::paths::clean_path;
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use git2::{self, ErrorCode};
+use request::StelaeQueryData;
 
 use super::super::errors::HTTPError;
 
@@ -38,7 +38,14 @@ pub async fn get_blob(
     let blob_path = clean_path(&remainder);
     let contenttype = get_contenttype(&blob_path);
     match blob {
-        Ok(content) => HttpResponse::Ok().insert_header(contenttype).body(content),
+        Ok(found_blob) => {
+            let content = found_blob.content;
+            let filepath = found_blob.path;
+            HttpResponse::Ok()
+                .insert_header(contenttype)
+                .insert_header((headers::HTTP_X_FILE_PATH, filepath))
+                .body(content)
+        }
         Err(error) => blob_error_response(&error, &namespace, &name),
     }
 }

--- a/src/server/git.rs
+++ b/src/server/git.rs
@@ -49,7 +49,14 @@ async fn get_blob(
     let blob_path = clean_path(&remainder);
     let contenttype = get_contenttype(&blob_path);
     match blob {
-        Ok(content) => HttpResponse::Ok().insert_header(contenttype).body(content),
+        Ok(found_blob) => {
+            let content = found_blob.content;
+            let filepath = found_blob.path;
+            HttpResponse::Ok()
+                .insert_header(contenttype)
+                .insert_header(("X-File-Path", filepath))
+                .body(content)
+        }
         Err(error) => blob_error_response(&error, &namespace, &name),
     }
 }

--- a/src/server/git.rs
+++ b/src/server/git.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use tracing_actix_web::TracingLogger;
 
 use super::errors::{CliError, HTTPError, StelaeError};
+use crate::server::headers;
 use crate::utils::git::{Repo, GIT_REQUEST_NOT_FOUND};
 use crate::utils::http::get_contenttype;
 use crate::{server::tracing::StelaeRootSpanBuilder, utils::paths::clean_path};
@@ -54,7 +55,7 @@ async fn get_blob(
             let filepath = found_blob.path;
             HttpResponse::Ok()
                 .insert_header(contenttype)
-                .insert_header(("X-File-Path", filepath))
+                .insert_header((headers::HTTP_X_FILE_PATH, filepath))
                 .body(content)
         }
         Err(error) => blob_error_response(&error, &namespace, &name),

--- a/src/server/headers.rs
+++ b/src/server/headers.rs
@@ -1,0 +1,15 @@
+//! Headers used in the Stelae server.
+
+/// Provides the relative file path (starting from the git repository)
+/// of the corresponding git blob.
+///
+/// This header is included in responses from the `git` microserver and the `_stelae` endpoint,
+/// indicating the location of the file within the repository.
+///
+/// Example:
+///
+/// For a URL request: `a/b/c/1`
+/// the header will be set as:
+///
+/// `X-File-Path: a/b/c/1/index.html`
+pub const HTTP_X_FILE_PATH: &str = "X-File-Path";

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,4 +6,5 @@ pub mod api;
 pub mod app;
 pub mod errors;
 pub mod git;
+pub mod headers;
 pub mod tracing;

--- a/src/stelae/archive.rs
+++ b/src/stelae/archive.rs
@@ -155,7 +155,10 @@ impl Archive {
 fn raise_error_if_in_existing_archive(path: &Path) -> anyhow::Result<bool> {
     let existing_archive_path = find_archive_path(path);
     match existing_archive_path {
-        Ok(_) => anyhow::bail!("You cannot create a new archive inside of an existing archive."),
+        Ok(_) => anyhow::bail!(format!(
+            "You cannot create a new archive inside of an existing archive at {} path.",
+            path.display()
+        )),
         Err(_) => Ok(false),
     }
 }

--- a/src/stelae/stele.rs
+++ b/src/stelae/stele.rs
@@ -73,15 +73,15 @@ impl Stele {
     /// # Errors
     /// Will error if unable to parse dependencies file from `targets/dependencies.json`
     pub fn get_dependencies(&self) -> anyhow::Result<Option<Dependencies>> {
-        let blob = self
+        let Ok(blob) = self
             .auth_repo
-            .get_bytes_at_path("HEAD", "targets/dependencies.json");
-        if let Ok(dependencies_blob) = blob {
-            let dependencies_str = String::from_utf8(dependencies_blob)?;
-            let dependencies = serde_json::from_str(&dependencies_str)?;
-            return Ok(Some(dependencies));
-        }
-        Ok(None)
+            .get_bytes_at_path("HEAD", "targets/dependencies.json")
+        else {
+            return Ok(None);
+        };
+        let dependencies_str = String::from_utf8(blob.content)?;
+        let dependencies = serde_json::from_str(&dependencies_str)?;
+        Ok(Some(dependencies))
     }
     /// Get Stele's repositories.
     /// # Errors
@@ -93,7 +93,7 @@ impl Stele {
         else {
             return Ok(None);
         };
-        let repositories_str = String::from_utf8(blob)?;
+        let repositories_str = String::from_utf8(blob.content)?;
         let repositories: Repositories = serde_json::from_str(&repositories_str)?;
         self.repositories = Some(repositories.clone());
         Ok(Some(repositories))
@@ -119,7 +119,7 @@ impl Stele {
         let Ok(blob) = self.auth_repo.get_bytes_at_path(committish, &file_path) else {
             return Ok(None);
         };
-        let targets_metadata_str = String::from_utf8(blob)?;
+        let targets_metadata_str = String::from_utf8(blob.content)?;
         let targets_metadata: TargetsMetadata = serde_json::from_str(&targets_metadata_str)?;
         Ok(Some(targets_metadata))
     }

--- a/tests/api/stelae/mod.rs
+++ b/tests/api/stelae/mod.rs
@@ -6,14 +6,14 @@ use actix_web::{test, Error};
 mod stelae_basic_test;
 mod stelae_multihost_test;
 
-/// Helper method which test all `fille_paths`` in `org_name`/`repo_name` repository on `branch_name`` branch with `expected` result
+/// Helper method which test all `file_paths`` in `org_name`/`repo_name` repository on `branch_name`` branch with `expected` result
 async fn test_stelae_paths(
     org_name: &str,
     repo_name: &str,
     file_paths: Vec<&str>,
     branch_name: &str,
     app: &impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = Error>,
-    expected: bool,
+    is_success: bool,
 ) {
     for file_path in file_paths {
         let req = test::TestRequest::get()
@@ -24,13 +24,23 @@ async fn test_stelae_paths(
             .to_request();
 
         let resp = test::call_service(&app, req).await;
-        let actual = if expected {
+        let actual = if is_success {
             resp.status().is_success()
         } else {
             resp.status().is_client_error()
         };
         let expected = true;
         assert_eq!(actual, expected);
+
+        if is_success {
+            let http_x_path = resp.headers().get("X-File-Path").unwrap().to_str().unwrap();
+            // strip leading slash from filepath (if exists)
+            let file_path = file_path.strip_prefix('/').unwrap_or(file_path);
+            assert!(
+                http_x_path.to_string().contains(file_path),
+                "\"{http_x_path}\" doesn't contain {file_path}"
+            );
+        }
     }
 }
 
@@ -41,7 +51,7 @@ async fn test_stelae_paths_with_head_method(
     file_paths: Vec<&str>,
     branch_name: &str,
     app: &impl Service<Request, Response = ServiceResponse<impl MessageBody>, Error = Error>,
-    expected: bool,
+    is_success: bool,
 ) {
     for file_path in file_paths {
         let req = test::TestRequest::default()
@@ -53,7 +63,7 @@ async fn test_stelae_paths_with_head_method(
             .to_request();
 
         let resp = test::call_service(&app, req).await;
-        let actual = if expected {
+        let actual = if is_success {
             resp.status().is_success()
         } else {
             resp.status().is_client_error()

--- a/tests/api/stelae/stelae_multihost_test.rs
+++ b/tests/api/stelae/stelae_multihost_test.rs
@@ -1,5 +1,3 @@
-//# def test_<method/code under test>_where_<conditions/inputs/state>_expect_<result>
-
 use crate::{archive_testtools::config::ArchiveType, common};
 
 use super::test_stelae_paths;

--- a/tests/basic/gitrepo_test.rs
+++ b/tests/basic/gitrepo_test.rs
@@ -12,7 +12,7 @@ fn test_get_bytes_at_path_when_empty_path_expect_index_html() {
     let actual = repo.get_bytes_at_path(COMMIT, "").unwrap();
     let expected = "<!DOCTYPE html>";
     assert!(
-        common::blob_to_string(actual).starts_with(expected),
+        common::blob_to_string(actual.content).starts_with(expected),
         "doesn't start with {expected}"
     );
 }
@@ -25,7 +25,7 @@ fn test_get_bytes_at_path_when_full_path_expect_data() {
     let actual = repo.get_bytes_at_path(COMMIT, "a/b/c.html").unwrap();
     let expected = "<!DOCTYPE html>";
     assert!(
-        common::blob_to_string(actual).starts_with(expected),
+        common::blob_to_string(actual.content).starts_with(expected),
         "doesn't start with {expected}"
     );
 }
@@ -38,7 +38,7 @@ fn test_get_bytes_at_path_when_omit_html_expect_data() {
     let actual = repo.get_bytes_at_path(COMMIT, "a/b/c").unwrap();
     let expected = "<!DOCTYPE html>";
     assert!(
-        common::blob_to_string(actual).starts_with(expected),
+        common::blob_to_string(actual.content).starts_with(expected),
         "doesn't start with {expected}"
     );
 }
@@ -51,7 +51,7 @@ fn test_get_bytes_at_path_when_omit_index_expect_data() {
     let actual = repo.get_bytes_at_path(COMMIT, "a/b/d").unwrap();
     let expected = "<!DOCTYPE html>";
     assert!(
-        common::blob_to_string(actual).starts_with(expected),
+        common::blob_to_string(actual.content).starts_with(expected),
         "doesn't start with {expected}"
     );
 }


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #71

- Refactor `find_bytes_at_path` to return additional metadata each time a blob is requested 
  - To make this possible, added a `Blob` struct that contains all the data needed by both `_stelae` and git microserver.
- Each `_stelae` and git server response now return an `X-File-Path` header. The value of this header is the filesystem path that the blob was found at. 
- Update tests to assert for the newly introuduced header.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/