### PR TITLE
feat: add `build_date` and `codified_date` columns to `data_repo_commits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Added
 
+- Add `build_date` and `codified_date` columns to `data_repo_commits` table ([#76])
 - Add `X-File-Path` header to `_stelae` and git microserver HTTP responses ([#70])
 - Added tests fot `stelae git` ([64])
 
@@ -23,6 +24,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+[#76]: https://github.com/openlawlibrary/stelae/pull/76
 [#70]: https://github.com/openlawlibrary/stelae/pull/70
 [#64]: https://github.com/openlawlibrary/stelae/pull/64
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "stelae"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "actix-http",
  "actix-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stelae"
 description = "A collection of tools in Rust and Python for preserving, authenticating, and accessing laws in perpetuity."
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 edition = "2021"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/migrations/sqlite/20250324170050_add_target_dates.down.sql
+++ b/migrations/sqlite/20250324170050_add_target_dates.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+PRAGMA foreign_keys = OFF;

--- a/migrations/sqlite/20250324170050_add_target_dates.up.sql
+++ b/migrations/sqlite/20250324170050_add_target_dates.up.sql
@@ -1,0 +1,14 @@
+-- Add up migration script here
+PRAGMA foreign_keys = OFF;
+
+ALTER TABLE data_repo_commits
+  DROP COLUMN date;
+
+ALTER TABLE data_repo_commits
+  ADD COLUMN codified_date TEXT;
+
+ALTER TABLE data_repo_commits
+  ADD COLUMN build_date TEXT;
+
+PRAGMA foreign_keys = ON;
+PRAGMA optimize;

--- a/src/db/models/data_repo_commits/manager.rs
+++ b/src/db/models/data_repo_commits/manager.rs
@@ -34,12 +34,13 @@ impl super::TxManager for DatabaseTransaction {
     /// # Errors
     /// Errors if the commits cannot be inserted.
     async fn insert_bulk(&mut self, data_repo_commits: Vec<DataRepoCommits>) -> anyhow::Result<()> {
-        let mut query_builder = QueryBuilder::new("INSERT OR IGNORE INTO data_repo_commits ( commit_hash, date, repo_type, auth_commit_hash, auth_commit_timestamp, publication_id ) ");
+        let mut query_builder = QueryBuilder::new("INSERT OR IGNORE INTO data_repo_commits ( commit_hash, codified_date, build_date, repo_type, auth_commit_hash, auth_commit_timestamp, publication_id ) ");
         for chunk in data_repo_commits.chunks(BATCH_SIZE) {
             query_builder.push_values(chunk, |mut bindings, dc| {
                 bindings
                     .push_bind(&dc.commit_hash)
-                    .push_bind(&dc.date)
+                    .push_bind(&dc.codified_date)
+                    .push_bind(&dc.build_date)
                     .push_bind(&dc.repo_type)
                     .push_bind(&dc.auth_commit_hash)
                     .push_bind(&dc.auth_commit_timestamp)

--- a/src/db/models/data_repo_commits/mod.rs
+++ b/src/db/models/data_repo_commits/mod.rs
@@ -20,8 +20,10 @@ pub trait TxManager {
 pub struct DataRepoCommits {
     /// Unique commit hash of the authentication repository.
     pub commit_hash: String,
-    /// Either codified date or date on which the commit was built on (build-date).
-    pub date: String,
+    /// Codified date.
+    pub codified_date: Option<String>,
+    /// Build date of the commit.
+    pub build_date: Option<String>,
     /// Type of the data repository. E.g. `html`.
     pub repo_type: String,
     /// Foreign key reference to the authentication commit hash.
@@ -37,7 +39,8 @@ impl DataRepoCommits {
     #[must_use]
     pub const fn new(
         commit_hash: String,
-        date: String,
+        codified_date: Option<String>,
+        build_date: Option<String>,
         repo_type: String,
         auth_commit_hash: String,
         auth_commit_timestamp: String,
@@ -45,7 +48,8 @@ impl DataRepoCommits {
     ) -> Self {
         Self {
             commit_hash,
-            date,
+            codified_date,
+            build_date,
             repo_type,
             auth_commit_hash,
             auth_commit_timestamp,

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -696,23 +696,14 @@ async fn process_commit<'commit>(
         );
         return Ok(());
     };
-    let Some(data_repo_commit_date) = targets_metadata
-        .codified_date
-        .or(targets_metadata.build_date)
-    else {
-        tracing::debug!(
-            "[{stele_name}] | Skipping commit {} without codified date or build date",
-            &auth_commit_hash
-        );
-        return Ok(());
-    };
     let auth_commit_timestamp = DateTime::from_timestamp(commit.time().seconds(), 0)
         .unwrap_or_default()
         .to_string();
 
     data_repo_commits_bulk.push(DataRepoCommits::new(
         targets_metadata.commit,
-        data_repo_commit_date,
+        targets_metadata.codified_date,
+        targets_metadata.build_date,
         data_repo.get_type().unwrap_or_default(),
         auth_commit_hash,
         auth_commit_timestamp,


### PR DESCRIPTION
The idea being that we can't always reliably rely on `auth_commit_timestamp` column to get the order of inserted commit hashes. Mainly because it can sometimes happen that the timestamp date is the same for all commits on a publication, thus making it impossible to figure out which commit was inserted last.

## Description (e.g. "Related to ...", etc.)

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/