### PR TITLE
Ndusan/cli changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Added
 
+- Make CLI more generic, any Rust project that depends on stelae can now re-export CLI ([#89])
+- Add `from_path` associated function to init `Repo` ([#89])
 - Add `_archive` endpoint ([#81])
 - Restrict `_archive` endpoint access on private repositories ([#81])
 
 ### Changed
 
-- Bump rust-version to `1.88` ([86])
+- Bump rust-version to `1.88` ([#86])
 
 ### Fixed
 
 ### Removed
 
+[#89]: https://github.com/openlawlibrary/stelae/pull/89
 [#86]: https://github.com/openlawlibrary/stelae/pull/86
 [#81]: https://github.com/openlawlibrary/stelae/pull/81
 

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -714,8 +714,8 @@ async fn insert_commit_hashes_from_auth_repository(
 /// # Errors
 /// Errors if the metadata target file cannot be found, the publication cannot be found,
 /// or the commit cannot be inserted into the database.
-async fn process_commit<'commit>(
-    commit: &git2::Commit<'commit>,
+async fn process_commit(
+    commit: &git2::Commit<'_>,
     stele: &Stele,
     data_repo: &Repository,
     stele_name: &str,

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -700,10 +700,6 @@ async fn insert_commit_hashes_from_auth_repository(
     Ok(())
 }
 
-#[expect(
-    clippy::elidable_lifetime_names,
-    reason = "Explicit lifetime improves clarity and consistency"
-)]
 /// Process the auth commit.
 ///
 /// The commit is used to get the metadata target file for the data repository.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,16 @@
 "
 )]
 #![allow(
+    clippy::non_std_lazy_statics,
+    reason = "Even though we'd ideally like to transition to a more modern approach, lazy_static is okay for now."
+)]
+#![allow(
+    clippy::pub_use,
+    reason = "We re-export some items from other modules, so this is okay"
+)]
+#![allow(
     clippy::arbitrary_source_item_ordering,
-    reason = "Source item order differences are acceptable; code is generated or does not rely on item ordering"
+    reason = "We at present don't care mind the order of items in modules. In the future we may want to enforce some order, but for now this is okay"
 )]
 
 pub mod db;

--- a/src/server/api/routes.rs
+++ b/src/server/api/routes.rs
@@ -3,10 +3,6 @@
     clippy::exit,
     reason = "We exit with 1 error code on any application errors"
 )]
-#![expect(
-    clippy::literal_string_with_formatting_args,
-    reason = "We use Actix web's wildcard .* to match all paths"
-)]
 use std::sync::Arc;
 use std::{process, sync::OnceLock};
 

--- a/src/server/api/routes.rs
+++ b/src/server/api/routes.rs
@@ -3,6 +3,10 @@
     clippy::exit,
     reason = "We exit with 1 error code on any application errors"
 )]
+#![expect(
+    clippy::literal_string_with_formatting_args,
+    reason = "We use Actix web's wildcard .* to match all paths"
+)]
 use std::sync::Arc;
 use std::{process, sync::OnceLock};
 

--- a/src/stelae/stele.rs
+++ b/src/stelae/stele.rs
@@ -182,7 +182,7 @@ impl Stele {
     }
 }
 
-///Config object for a Stele
+/// Config object for a Stele
 #[derive(Deserialize, Serialize)]
 pub struct Config {
     /// Name of the authentication repo (e.g. law).

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -150,8 +150,10 @@ pub enum Subcommands {
     clippy::expect_used,
     reason = "Expect that console logging can be initialized"
 )]
-pub fn init_tracing(archive_path: &Path, log_path: Option<String>) {
-    let log_dir: PathBuf = log_path.map_or_else(|| archive_path.join(".taf"), PathBuf::from);
+pub fn init_tracing(archive_path: &Path, log_path: &Option<String>) {
+    let log_dir: PathBuf = log_path
+        .as_ref()
+        .map_or_else(|| archive_path.join(".taf"), PathBuf::from);
 
     let debug_file_appender =
         rolling::never(&log_dir, "stelae-debug.log").with_max_level(Level::DEBUG);
@@ -220,7 +222,7 @@ pub fn run() {
     };
 
     let log_path = cli.log_path.clone();
-    init_tracing(&archive_path, log_path);
+    init_tracing(&archive_path, &log_path);
 
     match execute_command(&cli, archive_path) {
         Ok(()) => process::exit(0),


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Make CLI more generic, such that any other Rust project depending on stelae can re-export it's CLI.
- Add `from_path` associated function to init `Repo` instance

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/