### PR TITLE
Add `--force` flag and inconsistency auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 - Added support for ETags ([#98])
 - Add redirects for dynamic routes ([#97])
-- Added _date endpoint from portal into stele ([#100]) 
+- Added _date endpoint from portal into stele ([#100])
+- Add `--force` flag and automatic inconsistency detection to `stelae update` ([#108])
 
 ### Changed
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -74,19 +74,33 @@ impl Db for DatabaseConnection {
         };
         let options = any::AnyConnectOptions::from_str(db_url)?
             .log_slow_statements(log::LevelFilter::Warn, time::Duration::from_secs(1));
+        let db_kind = if db_url.starts_with("sqlite:///") {
+            DatabaseKind::Sqlite
+        } else {
+            anyhow::bail!("Unsupported database URL: {}", db_url);
+        };
         let pool = AnyPoolOptions::new()
             .max_connections(2 * num_cpus)
+            .after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    // Enable foreign key enforcement on every connection.
+                    // This is a per-connection SQLite setting (not persisted to the file),
+                    // so it must be applied here rather than in a one-off PRAGMA query.
+                    sqlx::query("PRAGMA foreign_keys = ON")
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+            })
             .connect_with(options)
             .await?;
-        let connection = match db_url {
-            url if url.starts_with("sqlite:///") => Self {
-                pool,
-                kind: DatabaseKind::Sqlite,
-            },
-            _ => anyhow::bail!("Unsupported database URL: {}", db_url),
+        let connection = Self {
+            pool,
+            kind: db_kind,
         };
         // Set journal mode to WAL. This way we support concurrent reads/writes without
-        // locking the database.
+        // locking the database. WAL mode is a database-level setting (persisted to the
+        // file header), so a single PRAGMA query is sufficient.
         sqlx::query("PRAGMA journal_mode=WAL;")
             .execute(&connection.pool)
             .await?;

--- a/src/db/models/data_repo_commits/manager.rs
+++ b/src/db/models/data_repo_commits/manager.rs
@@ -34,6 +34,33 @@ impl super::TxManager for DatabaseTransaction {
             .await?;
         Ok(data_repo_commits)
     }
+    /// Find the most-recently-recorded authentication commit hash for a given stele
+    /// and data repository.
+    ///
+    /// # Errors
+    /// Errors if the query fails.
+    async fn find_last_auth_commit_for_stele(
+        &mut self,
+        stele_id: &str,
+        data_repo_name: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let query = "
+            SELECT dc.auth_commit_hash
+            FROM data_repo_commits dc
+            LEFT JOIN publication p ON dc.publication_id = p.id
+            WHERE p.stele = $1
+            AND p.html_data_repo_name = $2
+            ORDER BY dc.auth_commit_timestamp DESC
+            LIMIT 1
+        ";
+        let row: Option<(String,)> = sqlx::query_as(query)
+            .bind(stele_id)
+            .bind(data_repo_name)
+            .fetch_optional(&mut *self.tx)
+            .await?;
+        Ok(row.map(|(hash,)| hash))
+    }
+
     /// Upsert a bulk of data repository commits into the database.
     ///
     /// # Errors

--- a/src/db/models/data_repo_commits/mod.rs
+++ b/src/db/models/data_repo_commits/mod.rs
@@ -13,6 +13,14 @@ pub trait TxManager {
         stele_id: &str,
         data_repo_name: &str,
     ) -> anyhow::Result<Vec<DataRepoCommits>>;
+    /// Find the most-recently-recorded authentication commit hash for a given stele
+    /// and data repository, ordered by `auth_commit_timestamp` descending.
+    /// Returns `None` if no commits have been recorded yet.
+    async fn find_last_auth_commit_for_stele(
+        &mut self,
+        stele_id: &str,
+        data_repo_name: &str,
+    ) -> anyhow::Result<Option<String>>;
     /// Insert a bulk of data repo commits.
     async fn insert_bulk(&mut self, data_repo_commits: Vec<DataRepoCommits>) -> anyhow::Result<()>;
     /// Find the latest commit for a publication, constrained by a valid ISO version date.

--- a/src/db/models/publication/manager.rs
+++ b/src/db/models/publication/manager.rs
@@ -178,6 +178,23 @@ impl super::TxManager for DatabaseTransaction {
         Ok(())
     }
 
+    /// Count the number of non-revoked publications for a given stele.
+    ///
+    /// # Errors
+    /// Errors if can't establish a connection to the database.
+    async fn count_non_revoked(&mut self, stele: &str) -> anyhow::Result<usize> {
+        let statement = "
+            SELECT COUNT(*) as count
+            FROM publication
+            WHERE revoked = 0 AND stele = $1
+        ";
+        let row: (i64,) = sqlx::query_as(statement)
+            .bind(stele)
+            .fetch_one(&mut *self.tx)
+            .await?;
+        Ok(usize::try_from(row.0).unwrap_or(0))
+    }
+
     /// Find all publication names by date and stele.
     ///
     /// # Errors

--- a/src/db/models/publication/mod.rs
+++ b/src/db/models/publication/mod.rs
@@ -69,6 +69,8 @@ pub trait TxManager {
         date: String,
         stele: String,
     ) -> anyhow::Result<Vec<Publication>>;
+    /// Count the number of non-revoked publications for a given stele.
+    async fn count_non_revoked(&mut self, stele: &str) -> anyhow::Result<usize>;
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/db/models/stele/manager.rs
+++ b/src/db/models/stele/manager.rs
@@ -20,4 +20,19 @@ impl super::TxManager for DatabaseTransaction {
             .last_insert_id();
         Ok(id)
     }
+
+    /// Delete a stele and all of its associated data via `ON DELETE CASCADE`.
+    ///
+    /// `PRAGMA foreign_keys = ON` is set at connection time, so a single
+    /// delete on the `stele` table cascades to all child tables automatically.
+    ///
+    /// # Errors
+    /// Errors if the delete statement fails.
+    async fn delete(&mut self, stele: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM stele WHERE name = $1")
+            .bind(stele)
+            .execute(&mut *self.tx)
+            .await?;
+        Ok(())
+    }
 }

--- a/src/db/models/stele/mod.rs
+++ b/src/db/models/stele/mod.rs
@@ -8,6 +8,11 @@ pub mod manager;
 pub trait TxManager {
     /// Create a stele.
     async fn create(&mut self, stele: &str) -> anyhow::Result<Option<i64>>;
+    /// Delete a stele and all of its associated data via cascade.
+    ///
+    /// Requires `PRAGMA foreign_keys = ON` (set at connection time) for the
+    /// `ON DELETE CASCADE` constraints to take effect.
+    async fn delete(&mut self, stele: &str) -> anyhow::Result<()>;
 }
 
 #[derive(sqlx::FromRow, Deserialize, Serialize)]

--- a/src/history/changes.rs
+++ b/src/history/changes.rs
@@ -56,13 +56,14 @@ use std::{
 #[actix_web::main]
 #[tracing::instrument(
     name = "Stelae update",
-    skip(raw_archive_path, archive_path, include, exclude)
+    skip(raw_archive_path, archive_path, include, exclude, force)
 )]
 pub async fn insert(
     raw_archive_path: &str,
     archive_path: PathBuf,
     include: &Vec<String>,
     exclude: &Vec<String>,
+    force: bool,
 ) -> Result<(), CliError> {
     if !include.is_empty() {
         tracing::info!("Following stele are included: {:#?}", include);
@@ -81,13 +82,20 @@ pub async fn insert(
             return Err(CliError::DatabaseConnectionError);
         }
     };
-    insert_changes_archive(&conn, raw_archive_path, &archive_path, include, exclude)
-        .await
-        .map_err(|err| {
-            tracing::error!("Failed to update stele in the archive");
-            tracing::error!("{err:?}");
-            CliError::GenericError
-        })
+    insert_changes_archive(
+        &conn,
+        raw_archive_path,
+        &archive_path,
+        include,
+        exclude,
+        force,
+    )
+    .await
+    .map_err(|err| {
+        tracing::error!("Failed to update stele in the archive");
+        tracing::error!("{err:?}");
+        CliError::GenericError
+    })
 }
 
 #[expect(
@@ -101,6 +109,7 @@ async fn insert_changes_archive(
     archive_path: &Path,
     include: &[String],
     exclude: &[String],
+    force: bool,
 ) -> anyhow::Result<()> {
     tracing::debug!("Inserting history into archive");
 
@@ -118,7 +127,7 @@ async fn insert_changes_archive(
         let mut tx = DatabaseTransaction {
             tx: conn.pool.begin().await?,
         };
-        match process_stele(&mut tx, &name, &mut stele, archive_path).await {
+        match process_stele(&mut tx, &name, &mut stele, archive_path, force).await {
             Ok(()) => {
                 tracing::debug!("Applying transaction for stele: {name}");
                 tx.commit().await?;
@@ -139,12 +148,17 @@ async fn insert_changes_archive(
     Ok(())
 }
 
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "Splitting would reduce readability"
+)]
 /// Process the stele and insert changes into the database
 async fn process_stele(
     tx: &mut DatabaseTransaction,
     name: &str,
     stele: &mut Stele,
     archive_path: &Path,
+    force: bool,
 ) -> anyhow::Result<()> {
     let Some(repositories) = stele.get_repositories()? else {
         tracing::warn!("No repositories found for stele: {name}");
@@ -176,14 +190,29 @@ async fn process_stele(
         .into_iter()
         .find(|repo| !repo.is_archived())
         .map(|repo| repo.name.clone());
+    // Collect historical HTML data repos once — used for both consistency checks and
+    // commit-hash insertion below.
+    let data_repos: Vec<&Repository> = repositories
+        .get_all_by_serve_type("historical")
+        .into_iter()
+        .filter(|repo| repo.custom.repository_type.as_deref() == Some("html"))
+        .collect();
+    // Check database consistency and rebuild if needed.
+    let needs_rebuild = if force {
+        tracing::info!("[{name}] | --force flag set, rebuilding database from scratch");
+        true
+    } else {
+        is_stele_inconsistent(tx, name, stele, &rdf, &data_repos).await?
+    };
+    if needs_rebuild {
+        if !force {
+            tracing::warn!("[{name}] | Rebuilding database from scratch due to inconsistency");
+        }
+        stele::TxManager::delete(tx, name).await?;
+    }
     insert_changes_from_rdf_repository(tx, rdf, name, current_html_repo_name.as_deref()).await?;
     // Insert commit hashes for data repositories with serve type 'historical'
-    let data_repos = repositories.get_all_by_serve_type("historical");
     for data_repo in data_repos {
-        // For now insert commit hashes only for repositories with repository type 'html'
-        if data_repo.custom.repository_type.as_deref() != Some("html") {
-            continue;
-        }
         insert_commit_hashes_from_auth_repository(tx, stele, data_repo).await?;
     }
     Ok(())
@@ -672,6 +701,90 @@ async fn revoke_same_date_publications(
         }
     }
     Ok(())
+}
+
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "Splitting would reduce readability"
+)]
+/// Check whether the database state for a stele is consistent with its git repositories.
+///
+/// Returns `true` if an inconsistency is detected, meaning the stele should be
+/// deleted from the database and fully rebuilt from scratch.
+///
+/// Two checks are performed:
+///
+/// Publication count: the number of entries in the RDF repository's
+/// `_publication/` directory at HEAD must be ≥ the number of non-revoked publications
+/// stored in the database.  A lower count indicates that the RDF repository was rolled
+/// back or force-pushed and publications were lost.
+///
+/// Authentication commit existence: for each historical HTML data
+/// repository, the most-recently-recorded `auth_commit_hash` in `data_repo_commits`
+/// must resolve to a real commit in the auth repository.  If it does not, the auth
+/// repository was force-pushed past that commit.
+async fn is_stele_inconsistent(
+    tx: &mut DatabaseTransaction,
+    stele_name: &str,
+    stele: &Stele,
+    rdf_repo: &Repo,
+    data_repos: &[&Repository],
+) -> anyhow::Result<bool> {
+    let db_pub_count = publication::TxManager::count_non_revoked(tx, stele_name).await?;
+    if db_pub_count == 0 {
+        // Fresh stele, nothing to be inconsistent with.
+        return Ok(false);
+    }
+
+    // Count publications in _publication/ at HEAD vs non-revoked in DB.
+    let head_commit = rdf_repo.repo.head()?.peel_to_commit()?;
+    let tree = head_commit.tree()?;
+    if let Ok(publications_dir_entry) = tree.get_path(&PathBuf::from("_publication")) {
+        let publications_subtree = rdf_repo.repo.find_tree(publications_dir_entry.id())?;
+        let rdf_pub_count = publications_subtree.len();
+        if rdf_pub_count < db_pub_count {
+            tracing::warn!(
+                "[{stele_name}] | Inconsistency detected: RDF repository has {rdf_pub_count} \
+                 publication(s) at HEAD but the database has {db_pub_count} non-revoked \
+                 publication(s). The RDF repository may have been force-pushed or rolled back."
+            );
+            return Ok(true);
+        }
+    }
+
+    // Most-recent auth_commit_hash for each data repo must exist in the auth repo.
+    for data_repo in data_repos {
+        let Some(last_auth_commit) = data_repo_commits::TxManager::find_last_auth_commit_for_stele(
+            tx,
+            stele_name,
+            &data_repo.name,
+        )
+        .await?
+        else {
+            continue;
+        };
+        let oid = match git2::Oid::from_str(&last_auth_commit) {
+            Ok(oid) => oid,
+            Err(err) => {
+                tracing::warn!(
+                    "[{stele_name}] | Could not parse stored auth commit hash \
+                     '{last_auth_commit}' as a git OID: {err:?}"
+                );
+                return Ok(true);
+            }
+        };
+        if stele.auth_repo.repo.find_commit(oid).is_err() {
+            tracing::warn!(
+                "[{stele_name}] | Inconsistency detected: auth commit '{last_auth_commit}' \
+                 for data repo '{}' is not present in the auth repository. \
+                 The auth repository may have been force-pushed.",
+                data_repo.name
+            );
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 #[expect(

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -68,6 +68,8 @@ pub enum StelaeSubcommands {
         include: Vec<String>,
         /// List of stelae to exclude in update
         exclude: Vec<String>,
+        /// Force a full rebuild of each stele's database records, skipping consistency checks.
+        force: bool,
     },
 }
 
@@ -102,9 +104,14 @@ impl CliProvider for Cli {
                 individual: *individual,
                 bind_to: bind_to.clone(),
             },
-            Subcommands::Update { include, exclude } => StelaeSubcommands::Update {
+            Subcommands::Update {
+                include,
+                exclude,
+                force,
+            } => StelaeSubcommands::Update {
                 include: include.clone(),
                 exclude: exclude.clone(),
+                force: *force,
             },
         }
     }
@@ -145,6 +152,11 @@ pub enum Subcommands {
         /// List of stelae to exclude in update
         #[arg(short = 'e', long = "exclude", num_args(1..))]
         exclude: Vec<String>,
+        /// Force a full rebuild of each stele's database records.
+        /// Skips consistency checks and always deletes and re-inserts all data for the stele.
+        /// Respects --include and --exclude filters.
+        #[arg(short = 'f', long = "force", default_value_t = false)]
+        force: bool,
     },
 }
 
@@ -218,9 +230,11 @@ pub fn execute_command<T: CliProvider>(cli: &T, archive_path: PathBuf) -> Result
             *individual,
             bind_to,
         ),
-        StelaeSubcommands::Update { include, exclude } => {
-            changes::insert(cli.archive_path(), archive_path, include, exclude)
-        }
+        StelaeSubcommands::Update {
+            include,
+            exclude,
+            force,
+        } => changes::insert(cli.archive_path(), archive_path, include, exclude, *force),
     }
 }
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Adds a `--force` flag to stelae update and automatic detection of database inconsistencies caused by force-pushes or repository rollbacks. When an inconsistency is detected (mismatched publication count or a missing auth commit), the stele is automatically wiped and rebuilt from scratch. `--force` skips the checks and always rebuilds. Also enables `PRAGMA foreign_keys = ON` per connection so cascade deletes work correctly.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
~[ ] Tests have been included and/or updated, as appropriate~
- [x] Docstrings have been included and/or updated, as appropriate
~[ ] Standalone docs have been updated accordingly~

## Automated tests, benchmarks and linters

You can run the tests, lints and benchmarks that are run on CI locally with:
```sh
just ci
```

[commit messages]: https://conventionalcommits.org/